### PR TITLE
docs: update ScreenContext sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,8 @@ export class AppComponent {
   constructor(private screenContext: ScreenContext) {
     this.screenContext
       .asObservable()
-      .subscribe({
-        next: (context) => {
-          console.log('Screen context changed:', context);
-        }
+      .subscribe((context) => {
+        console.log('Screen context changed:', context);
       });
   }
 }

--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ export class AppComponent {
   constructor(private screenContext: ScreenContext) {
     this.screenContext
       .asObservable()
-      .subscribe(context: ScreenContextData) {
-        console.log('Screen context changed:', context);
-      }
+      .subscribe({
+        next: (context) => {
+          console.log('Screen context changed:', context);
+        }
+      });
   }
 }
 ```


### PR DESCRIPTION
The signature of `.subscribe(context: ScreenContextData)` has been deprecated.  We need to use an observer instead:

```
.subscribe({
        next: (context) => {
          console.log('Screen context changed:', context);
        }
      });
```